### PR TITLE
Add missing dependency on pywin32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpnp"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
     { name = "Supper Pudding", email = "31290828+SuperPudding98@users.noreply.github.com" },
 ]
@@ -22,7 +22,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["more-itertools>=10.2.0,<11"]
+dependencies = ["more-itertools>=10.2.0,<11", "pywin32>=306"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.2.1,<9", "pytest-cases>=3.8.6,<4"]


### PR DESCRIPTION
winpnp depends on the pywin32 package, which accidentally wasn't included in pyproject.toml.
This is now fixed.