### PR TITLE
Add missing bluetooth property keys

### DIFF
--- a/src/winpnp/properties/keys/__init__.py
+++ b/src/winpnp/properties/keys/__init__.py
@@ -4,6 +4,7 @@ from winpnp.properties import kinds
 from winpnp.properties.pnp_property import PnpPropertyKey
 
 from . import (
+    bluetooth,
     dev_query,
     device,
     device_class,


### PR DESCRIPTION
A previous commit has already added the bluetooth property keys, but they were accidentally not imported in winpnp.properties.keys.__init__